### PR TITLE
handle unitsystem from client to server

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getReadProperties } from './utils';
+import { config } from './config';
 
 let api = {};
 
@@ -19,7 +20,10 @@ api.exchangeCode = async (code) => {
 api.getVehicles = async () => {
   const vehicleProperties = getReadProperties().join('.');
   const { data } = await instance.get(`/vehicles`, {
-    params: { vehicleProperties },
+    params: {
+      vehicleProperties,
+      unitSystem: config.unitSystem,
+    },
   });
   return data;
 };
@@ -30,6 +34,7 @@ api.getVehicle = async (vehicleId) => {
     params: {
       vehicleId,
       vehicleProperties,
+      unitSystem: config.unitSystem,
     },
   });
   return data;

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -175,7 +175,7 @@ const energyUtilitiesConfig = {
   singleSelectVin: '',
   vehicleProperties: [
     // the order will dictate the order of the UI components
-    properties.attributes,
+    properties.attributes, // a REQUIRED endpoint for this app
     properties.vin,
     properties.isPluggedIn,
     properties.chargeState,
@@ -197,11 +197,12 @@ const autoInsuranceConfig = {
     appName: 'Sky Insurance',
   },
   mode: 'test',
-  unitSystem: 'imperial',
+  unitSystem: 'metric',
   brandSelect: '',
   singleSelect: true,
   singleSelectVin: '',
   vehicleProperties: [
+    properties.attributes, // a REQUIRED endpoint for this app
     properties.vin,
     properties.odometer,
     properties.location,
@@ -220,6 +221,7 @@ const carSharingConfig = {
   singleSelect: true,
   singleSelectVin: '',
   vehicleProperties: [
+    properties.attributes, // a REQUIRED endpoint for this app
     properties.vin,
     properties.lockUnlock,
     properties.location,
@@ -241,6 +243,7 @@ const roadsideAssistanceConfig = {
   singleSelect: true,
   singleSelectVin: '',
   vehicleProperties: [
+    properties.attributes, // a REQUIRED endpoint for this app
     properties.vin,
     properties.location,
     properties.odometer,
@@ -275,6 +278,7 @@ const buildYourOwnConfig = {
    *  4. The api methods. What car info to retrieve. What vehicle actions (ex: lock/unlock) can be made
    */
   vehicleProperties: [
+    properties.attributes, // a REQUIRED endpoint for this app
     properties.vin,
     // properties.someVehicleProperty,
   ],

--- a/server/index.js
+++ b/server/index.js
@@ -65,9 +65,10 @@ app.get('/exchange', async function(req, res) {
 // Gets a list of authorized vehicles and info for the first vehicle in that list
 app.get('/vehicles', authenticate, async function(req, res) {
   try {
+    const unitSystem = req.query.unitSystem;
+    const vehicleProperties = req.query.vehicleProperties?.split('.');
     let vehicles = [];
     let selectedVehicle = {};
-    const vehicleProperties = req.query.vehicleProperties?.split('.');
 
     // in the event some vehicles fail to disconnect, we'll return those vehicles along with this error message
     const error = req.query.error === 'disconnection-failure' ? 'Some vehicles failed to disconnect' : undefined;
@@ -78,7 +79,7 @@ app.get('/vehicles', authenticate, async function(req, res) {
     // TODO: use Promise.all for these two async calls
     if (vehicleIds.length > 0) {
       vehicles = await getVehiclesWithAttributes(vehicleIds, accessToken);
-      selectedVehicle = await getVehicleInfo(vehicles[0].id, accessToken, vehicleProperties);
+      selectedVehicle = await getVehicleInfo(vehicles[0].id, accessToken, vehicleProperties, unitSystem);
     }
     res.status(200).json({
       vehicles,
@@ -96,9 +97,9 @@ app.get('/vehicle', authenticate, async function(req, res) {
   try {
     const vehicleProperties = req.query.vehicleProperties?.split('.');
     const { accessToken } = req.tokens;
-    const vehicleId = req.query.vehicleId;
+    const { vehicleId, unitSystem } = req.query;
 
-    const vehicleData = await getVehicleInfo(vehicleId, accessToken, vehicleProperties);
+    const vehicleData = await getVehicleInfo(vehicleId, accessToken, vehicleProperties, unitSystem);
     console.log(vehicleData);
     res.json(vehicleData);
   } catch (err) {

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -97,6 +97,7 @@ const handleSettlement = (settlement, path, errorMessage = 'Information unavaila
  * @param {string} vehicleId 
  * @param {string} accessToken
  * @param {Array} requestedProperties list of desired vehicle properties
+ * @param {string} unitSystem imperial or metric
  * @param {string} [make] required only for brand-specific endpoints 
  * @returns {object} vehicle properties matching requestedProperties
  * 
@@ -104,10 +105,9 @@ const handleSettlement = (settlement, path, errorMessage = 'Information unavaila
  * And store this information in a database to avoid excessive api calls to Smartcar and to the vehicle
  * To update data that may have gone stale, you can poll data or use our webhooks
  */
-const getVehicleInfo = async (vehicleId, accessToken, requestedProperties = [], make) => {
-  make = 'CHEVROLET';
+const getVehicleInfo = async (vehicleId, accessToken, requestedProperties = [], unitSystem, make) => {
   const vehicleInfo = { id: vehicleId};
-  const vehicle = createSmartcarVehicle(vehicleId, accessToken);
+  const vehicle = createSmartcarVehicle(vehicleId, accessToken, unitSystem);
   
   // Generate list of vehicle endpoints
   const endpoints = [];

--- a/server/utils/vehicleProperties.js
+++ b/server/utils/vehicleProperties.js
@@ -170,7 +170,7 @@ const vehicleProperties = {
     process: (batchResponse) => {
       try {
         const tirePressure = batchResponse.tirePressure();
-        const { meta, ...remainingValues } = location;
+        const { meta, ...remainingValues } = tirePressure;
         return remainingValues;
       } catch (err) {
         return handleError(err);


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1205065341991195/f

This PR does the following:
1. added attributes to every config with the REQUIRED comment (this was throwing a permission error)
2. pass unitSystem in the two get requests. 
3. Fixed an error in `vehicleProperties` in server

Notes:
1. Maybe we should move `properties.attributes` to a separate field like `requiredVehicleProperties` so people it's clearer that it's getting read as a permission but it does not affect the UI layout
2. All the other requests (like setAmperage) technically also need unitSystem to be passed or it will default to "imperial" but since it doesn't affect the payload in anyway, it's fine to leave it

Waiting on other changes before we can confirm this works with the UI but here's the payloads, metric and imperial

![autoInsurancePayload](https://github.com/smartcar/starter-app-react-node/assets/119897746/7425be45-3839-4cf5-ac37-0bc9a3b18d1d)
![roadsidePayload](https://github.com/smartcar/starter-app-react-node/assets/119897746/171dbdc2-80c3-4fc2-b1d6-50524aa9c1d8)
