### PR TITLE
chore: remove reference to test mode

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -21,7 +21,7 @@ In production, replace the localhosts with the correct client and server urls.
 
 ## About the code
 
-**Custom configuration**: The configuration file `config.js` contains application specific settings that allow for quick customizations. Includes displayed properties, UI, unit system, mode (live, test, simulated), brand select, single select. Customize one of the four prebuilt configurations or build your own from scratch!
+**Custom configuration**: The configuration file `config.js` contains application specific settings that allow for quick customizations. Includes displayed properties, UI, unit system, mode (live, simulated), brand select, single select. Customize one of the four prebuilt configurations or build your own from scratch!
 
 **Components**:
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -39,7 +39,7 @@ const App = () => {
     redirectUri: process.env.REACT_APP_REDIRECT_URI,
     // set scope of permissions: https://smartcar.com/docs/api/#permissions
     scope: getPermissions(),
-    mode: config.mode, // one of ['live', 'test', 'simulated']
+    mode: config.mode, // one of ['live', 'simulated']
     onComplete,
   });
 

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -307,7 +307,7 @@ const buildYourOwnConfig = {
    * Section 2: Configure the Smartcar instance and Connect flow
    * You can also do this directly where smartcar gets instantiated in App.jsx
    */
-  mode: 'live', // one of ['live', 'test', 'simulated']
+  mode: 'live', // one of ['live', 'simulated']
   unitSystem: 'imperial',
   brandSelect: '',
   singleSelect: false,

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ const client = new smartcar.AuthClient({
   clientId: process.env.SMARTCAR_CLIENT_ID,
   clientSecret: process.env.SMARTCAR_CLIENT_SECRET,
   redirectUri: process.env.SMARTCAR_REDIRECT_URI,
-  mode: 'live', // one of ['live', 'test', 'simulated']
+  mode: 'live', // one of ['live', 'simulated']
 });
 
 // Exchanges code for access object, attaches access object to session cookie as a JWT


### PR DESCRIPTION
With the merge of test and simulated mode, we can remove the reference to test mode.